### PR TITLE
Fix public team codes

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,13 +3,13 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
     match /index/{document}{
-      allow read: if request.auth.uid != null;
+      allow read: if false; //if request.auth.uid != null;
     }
     match /users/{document}{
       allow read: if request.auth.uid != null;
     }
     match /teams/{document}{
-      allow read: if request.auth.uid != null;
+      allow read: if false; //request.auth.uid != null;
     }
     match /levels/{document}{
       allow read,write: if false;


### PR DESCRIPTION
The old rules allowed anyone to fetch the team codes and join any team.